### PR TITLE
fix: delete faulty argument from rvest::html_text() function

### DIFF
--- a/R/download_helpers.R
+++ b/R/download_helpers.R
@@ -17,7 +17,7 @@ get_bfs_asset_info <- function(ds) {
   # Retrieve asset number
   # 'asset_number' is used to construct the current read_paths for BFS assets from the DAM API.
   ds$asset_number <- asset_page %>%
-    rvest::html_text(ds$data_id) %>%
+    rvest::html_text() %>%
     stringr::str_extract("https://.*assets/.*/") %>%
     stringr::str_extract("[0-9]+")
 


### PR DESCRIPTION
- update in rvest package made this necessary

closes #28 